### PR TITLE
remove array pref override [patch]

### DIFF
--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -1,6 +1,5 @@
 const typescriptRules = {
   '@typescript-eslint/adjacent-overload-signatures': 2,
-  '@typescript-eslint/array-type': [2, 'generic'],
   '@typescript-eslint/await-thenable': 2,
   '@typescript-eslint/ban-types': [
     2,


### PR DESCRIPTION
## Change Type

* [ ] Feature
* [x] Chore
* [ ] Bug Fix

## Change Level

* [ ] major
* [ ] minor
* [x] patch

## Further Information (screenshots, bug report links, etc)
i think this is technically a major. the default is to error on `Array<thing>`, so i just removed the rule