### PR TITLE
swap out deprecated rule for replacement[patch]

### DIFF
--- a/rules/react.js
+++ b/rules/react.js
@@ -14,7 +14,7 @@ const a11yRules = {
   'jsx-a11y/iframe-has-title': 2,
   'jsx-a11y/img-redundant-alt': 2,
   'jsx-a11y/interactive-supports-focus': 2,
-  'jsx-a11y/label-has-for': 2,
+  'jsx-a11y/label-has-associated-control': [2, { assert: 'either', depth: 3 }],
   'jsx-a11y/mouse-events-have-key-events': 2,
   'jsx-a11y/no-access-key': 2,
   'jsx-a11y/no-distracting-elements': 2,


### PR DESCRIPTION
## Change Type

* [ ] Feature
* [x] Chore
* [ ] Bug Fix

## Further Information (screenshots, bug report links, etc)
`label-has-for` is deprecated in favor of `label-has-associated-control`