### PR TITLE
disable the delimiter style rule when using prettier ts

### DIFF
--- a/rules/index.js
+++ b/rules/index.js
@@ -12,6 +12,7 @@ const prettierRules = {
 }
 const prettierTsRules = {
   'prettier/prettier': [2, prettierTsFormat],
+  '@typescript-eslint/member-delimiter-style': 0,
 }
 
 const defaultParserOptions = {


### PR DESCRIPTION
## Change Type

* [ ] Feature
* [ ] Chore
* [x] Bug Fix

## Change Level

* [ ] major
* [ ] minor
* [x] patch

## Further Information (screenshots, bug report links, etc)
our TS config specifies commas in type definitions and prettier removes them, resulting in a conflict