### PR TITLE
[major] - Adjust exports so we can use latest Prettier features.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Jane's ESLint plugin and configurations.
 
 [![npm version](https://img.shields.io/npm/v/eslint-plugin-jane.svg)](https://npm.im/eslint-plugin-jane) [![CircleCI](https://circleci.com/gh/jane/eslint-plugin-jane.svg?style=svg)](https://circleci.com/gh/jane/eslint-plugin-jane) [![Maintainability](https://api.codeclimate.com/v1/badges/33e6dcb7e992c8d799e6/maintainability)](https://codeclimate.com/github/jane/eslint-plugin-jane/maintainability)
 
---------
+---
 
 ## Installation
 
@@ -13,6 +13,7 @@ Jane's ESLint plugin and configurations.
 ## Usage
 
 .eslintrc.json:
+
 ```json
 {
   "root": true,
@@ -21,19 +22,17 @@ Jane's ESLint plugin and configurations.
     "plugin:jane/react",
     "plugin:jane/node",
     "plugin:jane/typescript",
-    "plugin:jane/prettier-ts",
     "plugin:jane/prettier",
     "plugin:jane/jest"
   ],
-  "plugins": [
-    "jane"
-  ]
+  "plugins": ["jane"]
 }
 ```
 
 You can extend any or all of the exported configurations.
 If you are using the typescript plugin, some of the rules require this to be
 added to the .eslintrc file
+
 ```json
 "parser": "@typescript-eslint/parser",
 "parserOptions": {
@@ -44,10 +43,9 @@ added to the .eslintrc file
 You can also use or extend our Prettier config:
 
 .prettierrc.js:
+
 ```javascript
 module.exports = require('eslint-plugin-jane/prettier')
-// OR for TS files
-module.exports = require('eslint-plugin-jane/prettier-ts')
 ```
 
 ## License

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-jane",
-  "version": "11.0.0-dev.2",
+  "version": "11.0.0-dev.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-jane",
-  "version": "10.0.0",
+  "version": "11.0.0-dev.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-jane",
-  "version": "11.0.0-dev.1",
+  "version": "11.0.0-dev.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-jane",
-  "version": "11.0.0-dev.0",
+  "version": "11.0.0-dev.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-plugin-jane",
   "description": "Jane's ESLint plugin and configurations",
-  "version": "10.0.0",
+  "version": "11.0.0-dev.0",
   "author": "Jane",
   "license": "MIT",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     ]
   },
   "peerDependencies": {
-    "eslint": "^7.16.0"
+    "eslint": "^7.16.0",
+    "prettier": "^2.5.1"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-plugin-jane",
   "description": "Jane's ESLint plugin and configurations",
-  "version": "11.0.0-dev.2",
+  "version": "11.0.0-dev.3",
   "author": "Jane",
   "license": "MIT",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-plugin-jane",
   "description": "Jane's ESLint plugin and configurations",
-  "version": "11.0.0-dev.0",
+  "version": "11.0.0-dev.1",
   "author": "Jane",
   "license": "MIT",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-plugin-jane",
   "description": "Jane's ESLint plugin and configurations",
-  "version": "11.0.0-dev.1",
+  "version": "11.0.0-dev.2",
   "author": "Jane",
   "license": "MIT",
   "main": "index.js",

--- a/prettier-ts.js
+++ b/prettier-ts.js
@@ -1,1 +1,0 @@
-module.exports = require('./rules/prettier-ts')

--- a/rules/index.js
+++ b/rules/index.js
@@ -41,14 +41,18 @@ const plugin = {
         browser: true,
       },
       plugins: ['react', 'jsx-a11y', 'react-hooks'],
-      extends: ['plugin:import/warnings'],
+      extends: ['plugin:import/warnings', 'prettier'],
       rules: Object.assign({}, reactRules, a11yRules),
     },
     node: {
       env: {
         node: true,
       },
-      extends: ['plugin:import/warnings', 'plugin:node/recommended'],
+      extends: [
+        'plugin:import/warnings',
+        'plugin:node/recommended',
+        'prettier',
+      ],
       rules: nodeRules,
     },
     jest: {
@@ -56,12 +60,12 @@ const plugin = {
         jest: true,
       },
       plugins: ['jest'],
-      extends: ['plugin:import/warnings'],
+      extends: ['plugin:import/warnings', 'prettier'],
       rules: jestRules,
     },
     prettier: {
       plugins: ['prettier'],
-      extends: ['plugin:import/warnings'],
+      extends: ['plugin:import/warnings', 'prettier'],
       rules: prettierRules,
     },
     typescript: {
@@ -69,6 +73,7 @@ const plugin = {
       extends: [
         'plugin:import/warnings',
         'plugin:@typescript-eslint/recommended',
+        'prettier',
       ],
       rules: typescriptRules,
       parser: '@typescript-eslint/parser',

--- a/rules/index.js
+++ b/rules/index.js
@@ -1,5 +1,4 @@
 const prettierFormat = require('./prettier')
-const prettierTsFormat = require('./prettier-ts')
 
 const { nodeRules } = require('./node')
 const { a11yRules, reactRules } = require('./react')
@@ -9,9 +8,6 @@ const { typescriptRules } = require('./typescript')
 
 const prettierRules = {
   'prettier/prettier': [2, prettierFormat],
-}
-const prettierTsRules = {
-  'prettier/prettier': [2, prettierTsFormat],
 }
 
 const defaultParserOptions = {
@@ -67,11 +63,6 @@ const plugin = {
       plugins: ['prettier'],
       extends: ['plugin:import/warnings'],
       rules: prettierRules,
-    },
-    'prettier-ts': {
-      plugins: ['prettier'],
-      extends: ['plugin:import/warnings', 'prettier'],
-      rules: prettierTsRules,
     },
     typescript: {
       plugins: ['@typescript-eslint'],

--- a/rules/prettier-ts.js
+++ b/rules/prettier-ts.js
@@ -1,9 +1,0 @@
-module.exports = {
-  arrowParens: 'always',
-  parser: 'typescript',
-  printWidth: 80,
-  semi: false,
-  singleQuote: true,
-  tabWidth: 2,
-  trailingComma: 'es5',
-}

--- a/rules/prettier.js
+++ b/rules/prettier.js
@@ -1,6 +1,5 @@
 module.exports = {
   arrowParens: 'always',
-  parser: 'babel',
   printWidth: 80,
   semi: false,
   singleQuote: true,

--- a/rules/prettier.js
+++ b/rules/prettier.js
@@ -5,4 +5,5 @@ module.exports = {
   singleQuote: true,
   tabWidth: 2,
   trailingComma: 'es5',
+  quoteProps: 'preserve',
 }

--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -24,7 +24,7 @@ const typescriptRules = {
     2,
     {
       multiline: {
-        delimiter: 'comma',
+        delimiter: 'none',
         requireLast: true,
       },
       singleline: {

--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -28,8 +28,8 @@ const typescriptRules = {
         requireLast: true,
       },
       singleline: {
-        delimiter: 'comma',
-        requireLast: true,
+        delimiter: 'semi',
+        requireLast: false,
       },
     },
   ],


### PR DESCRIPTION
## Change Type

* [x] Feature
* [ ] Chore
* [ ] Bug Fix

## Change Level

* [x] major
* [ ] minor
* [ ] patch

## Further Information (screenshots, bug report links, etc)
* Prettier supports TS files out of the box, so remove prettier-ts export. Clients will need to adjust if they were using this and instead use the exported `prettier`
* Prettier also runs figures out the parser to use based on the file extension, so it can now support markdown, yaml, json, etc. files as well. 
