### PR TITLE
[minor] Chore/restrict imports from lodash and recompose.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-jane",
-  "version": "11.2.1",
+  "version": "11.2.2-dev.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-jane",
-  "version": "11.1.0",
+  "version": "11.2.0-dev.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-plugin-jane",
   "description": "Jane's ESLint plugin and configurations",
-  "version": "11.2.1",
+  "version": "11.2.2-dev.0",
   "author": "Jane",
   "license": "MIT",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-plugin-jane",
   "description": "Jane's ESLint plugin and configurations",
-  "version": "11.1.0",
+  "version": "11.2.0-dev.0",
   "author": "Jane",
   "license": "MIT",
   "main": "index.js",

--- a/rules/recommended.js
+++ b/rules/recommended.js
@@ -88,6 +88,7 @@ const baseRules = {
   'no-proto': 2,
   'no-redeclare': 2,
   'no-regex-spaces': 2,
+  'no-restricted-imports': [2, { 'paths': ['lodash', 'recompose'] }],
   'no-restricted-syntax': [2, 'LabeledStatement', 'WithStatement'],
   'no-return-assign': [2, 'except-parens'],
   'no-script-url': 2,


### PR DESCRIPTION
## Change Type

* [x] Feature
* [ ] Chore
* [ ] Bug Fix

## Change Level

* [ ] major
* [ ] minor
* [x] patch

## Further Information (screenshots, bug report links, etc)

Having this rule will prevent `import { debounce } from "lodash"` and recommend using `import debounce from lodash/debounce`. (similar for recompose). This will allow for better bundle splitting and so that we can remove this:

https://github.com/jane/jane-com/blob/046adcc30176054cd8f4d6129780c14dae5f2128/babel.config.js#L17

